### PR TITLE
Fix Mapping Driver guesser for new entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.1.3",
         "doctrine/inflector": "^1.2|^2.0",
-        "nikic/php-parser": "^4.0",
+        "nikic/php-parser": "^4.11",
         "symfony/config": "^4.0|^5.0",
         "symfony/console": "^4.0|^5.0",
         "symfony/dependency-injection": "^4.0|^5.0",

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -284,7 +284,7 @@ final class DoctrineHelper
             foreach ($mappings as [$prefix, $driver]) {
                 $diff = substr_compare($namespace, $prefix, 0);
 
-                if (null === $lowestCharacterDiff || $diff < $lowestCharacterDiff) {
+                if ($diff >= 0 && (null === $lowestCharacterDiff || $diff < $lowestCharacterDiff)) {
                     $foundDriver = $driver;
                 }
             }


### PR DESCRIPTION
The current code compares the output of substr_compare and picks the lowest result, which should mean the one with the greater overlap. However that function returns a negative value when there's no overlap at all. Here's an example:

```
php > echo substr_compare("App\Entity\Something\Other", "App\Entity", 0);
16 # 16-char difference
php > echo substr_compare("App\Entity\Something\Other", "App\Entity\Something", 0);
6 # 10-char advantage to the previous one, this Mapping Driver will be picked
php > echo substr_compare("App\Entity\Something\Other", "hello", 0);
-1 # Woops!
php > echo substr_compare("App\Entity\Something\Other", "Opp\Ontoto\App\Entity", 0);
-14 # This would be the picked one :(
```

The patch just checks for the value to be positive, as any negative value would mean the namespace has no overlap.

**Update:** I've also bumped the requirement for php-parser to `^4.11` because that's when the `addAttribute()` method was added. See: https://github.com/nikic/PHP-Parser/blob/master/CHANGELOG.md#version-4110-2021-07-03